### PR TITLE
Show attachments (photo, video, share, ...)

### DIFF
--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -34,6 +34,30 @@ function InteractiveCli(){
   this.currentConversationId = undefined;
 }
 
+function renderMessage(userId, author, message) {
+  var msg;
+
+  if (author.id != messenger.userId) {
+    msg = author.name.green;
+  } else {
+    msg = author.name;
+  }
+
+  msg += " : "
+
+  if (message.body !== "")
+    msg += message.body + " ";
+
+  if (message.attachments) {
+    for (var i = 0; i < message.attachments.length; i++) {
+      var a = message.attachments[i];
+      msg += '[ '.red + a.attach_type + ' ]'.red;
+    }
+  }
+
+  return msg;
+}
+
 InteractiveCli.prototype.initializeConversationViewFromFbid = function(id) {
   var user = messenger.users[id];
   this.currentConversationId = id;
@@ -56,15 +80,8 @@ InteractiveCli.prototype.initializeConversationViewFromFbid = function(id) {
         authorString = authorString.substr('fbid:'.length);
 
       var author = messenger.users[authorString];
+      var msg = renderMessage(messenger.userId, author, message);
 
-      var msg = '';
-      if (author.id != messenger.userId) {
-        msg = author.name.green;
-      } else {
-        msg = author.name;
-      }
-
-      msg += " : " + message.body;
       interactive.threadHistory.push(msg);
     }
     interactive.printThread();
@@ -108,15 +125,8 @@ InteractiveCli.prototype.readPullMessage = function(message) {
     }
   }
 
+  var msg = renderMessage(messenger.userId, author, message);
 
-  var msg = '';
-  if (author.id != messenger.userId) {
-    msg = author.name.green;
-  } else {
-    msg = author.name;
-  }
-
-  msg += " : " + message.body;
   interactive.threadHistory.push(msg);
   interactive.printThread();
 };

--- a/scripts/listeners.js
+++ b/scripts/listeners.js
@@ -11,18 +11,33 @@ Listeners.prototype.getMessagesListener = function(nb, searchId, callback) {
   callback(id);
 };
 
+function printThreadSnippet(thread, idx) {
+  var line = '[' + idx.toString().cyan + '] ' + thread.name.green + ' : ';
+  if (thread.snippet !== '')
+    line += thread.snippet + ' ';
+
+  for(var j = 0; j < thread.attachments.length; j++) {
+    var a = thread.attachments[j];
+    line += '[ '.red + a.attach_type + ' ]'.red;
+  }
+
+  console.log(line);
+}
+
 Listeners.prototype.getConversationsListener = function(userId, heading, cb) {
     messenger.getThreads(function(err,threads) {
     util.refreshConsole();
     options = {};
     for (var i = 0; i < threads.length; ++i) {
-        console.log('[' + i.toString().cyan + '] ' + threads[i].name.green + ' : ' + threads[i].snippet);
-        options[i] = threads[i].thread_fbid;
+        var thread = threads[i];
+        printThreadSnippet(thread, i);
 
-        if (threads[i].thread_fbid == userId) {
+        options[i] = thread.thread_fbid;
+
+        if (thread.thread_fbid == userId) {
           continue;
         }
-        heading[i] = {fbid: threads[i].thread_fbid, name: threads[i].name, unread: 0};
+        heading[i] = {fbid: thread.thread_fbid, name: thread.name, unread: 0};
     }
 
     process.stdout.write("Select conversation : ");
@@ -37,13 +52,15 @@ Listeners.prototype.getGroupConversationsListener = function(userId, heading, cb
     util.refreshConsole();
     options = {};
     for (var i = 0; i < threads.length; ++i) {
-        console.log('[' + i.toString().cyan + '] ' + threads[i].name.green + ' : ' + threads[i].snippet);
-        options[i] = threads[i].thread_fbid;
+        var thread = threads[i];
+        printThreadSnippet(thread, i);
 
-        if (threads[i].thread_fbid == userId) {
+        options[i] = thread.thread_fbid;
+
+        if (thread.thread_fbid == userId) {
           continue;
         }
-        heading[i] = {fbid: threads[i].thread_fbid, name: threads[i].name, unread: 0};
+        heading[i] = {fbid: thread.thread_fbid, name: thread.name, unread: 0};
     }
 
     process.stdout.write("Select conversation : ");

--- a/scripts/messenger.js
+++ b/scripts/messenger.js
@@ -232,9 +232,12 @@ Messenger.prototype.getLastMessage = function(recipient, recipientId, count, cal
                   'thread_fbid': m.thread_fbid,
                   'timestamp': m.timestamp,
                   'timestamp_datetime': m.timestamp_datetime
-              };
+              }
 
-              data.push(obj);
+              if (m.has_attachment)
+                obj.attachments = m.attachments;
+
+               data.push(obj);
           }
         }
 
@@ -293,7 +296,12 @@ Messenger.prototype.getThreads = function(callback) {
 
             for (j = 0; j < threads.length; ++j) {
               if (threads[j]['other_user_fbid'] == participants[i]['fbid']) {
-                data.push({'name': name, 'snippet' : threads[j]['snippet'], 'thread_fbid': threads[j]['thread_fbid']});
+                data.push({
+                  'name': name,
+                  'snippet': threads[j]['snippet'],
+                  'attachments': threads[j]['snippet_attachments'],
+                  'thread_fbid': threads[j]['thread_fbid']
+                });
                 break;
               }
             }


### PR DESCRIPTION
Message attachments such as photos, videos, stickers, external links (shares) and files are now shown as tags appended to messages.

In the main menu:

![threads-with-attachments](https://cloud.githubusercontent.com/assets/451178/21609986/72e732b2-d193-11e6-8c5f-34c853687c7b.png)

In a chat:

![chat-with-attachments](https://cloud.githubusercontent.com/assets/451178/21610042/bf03043c-d193-11e6-88e8-d015bbf64334.png)