### PR TITLE
Added /view command to open attachments in a browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "events": "^1.1.0",
     "fs": "0.0.2",
     "node-notifier": "^1.0.0",
+    "open": "0.0.5",
     "phantomjs-prebuilt": "^2.1.7",
     "prompt": "^1.0.0",
     "request": "^2.72.0",


### PR DESCRIPTION
I have added a `/view #` command which opens the link of an attachment in the default browser. 

Attachments are numbered starting from 0. This resets to 0 when a new conversation is opened. 

Using `/view` and an appropriate number will open the link to the attachment in a browser. An inappropriate number will result in an error. 