### PR TITLE
Add imgcat support for iterm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "crypto": "0.0.3",
     "events": "^1.1.0",
     "fs": "0.0.2",
+    "imgcat": "^2.3.0",
     "node-notifier": "^1.0.0",
     "open": "0.0.5",
     "phantomjs-prebuilt": "^2.1.7",

--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -14,6 +14,7 @@ var stdout = process.stdout;
 var crypt = new Crypt('password');
 const path = require('path');
 const notifier = require('node-notifier');
+const imgcat = require('imgcat');
 
 // 0 is select conversation, 1 is send message
 var action = 0;
@@ -27,8 +28,8 @@ var emitter = new events.EventEmitter();
 var heading = new Heading();
 var listeners = new Listeners();
 
-var atts = 0;
-var attsNo = [];
+var atts = [];
+var attsNo = 0;
 
 function InteractiveCli(){
   this.pull = new Pull();
@@ -57,33 +58,38 @@ function renderMessage(userId, author, message) {
     for (var i = 0; i < message.attachments.length; i++) {
       var a = message.attachments[i];
       var attType;
+      var attURL;
       if (a.attach_type == 'sticker' || a.attach_type == 'video') {
-        atts[attsNo] = a.url;
+        attURL = a.url;
         attType = a.attach_type;
       }
       else if (a.attach_type == 'share') {
-        atts[attsNo] = a.share.uri;
+        attURL = a.share.uri;
         attType = a.attach_type;
       }
       else if (a.attach_type == 'photo') {
-        atts[attsNo] = a.large_preview_url;
+        attURL = a.large_preview_url;
         attType = a.attach_type;
       }
       else if (a.attach_type == 'animated_image') {
-        atts[attsNo] = a.preview_url;
+        attURL = a.preview_url;
         attType = 'gif'
       }
       else if (a.attach_type == 'file') {
-        atts[attsNo] = a.url;
+        attURL = a.url;
         if (a.name.startsWith("audioclip")) {
           attType = 'audio clip'
         } else {
           attType = 'file'
         }
       }
-      x = '' + attsNo
-      msg += '[ '.red + attType + " " + x.cyan + ' ]'.red;
-      attsNo++;
+
+      if (attURL && attType) {
+        atts[attsNo] = {url: attURL, type: attType};
+        x = '' + attsNo
+        msg += '[ '.red + attType + " " + x.cyan + ' ]'.red;
+        attsNo++;
+      }
     }
   }
 
@@ -248,10 +254,21 @@ InteractiveCli.prototype.handler = function(choice) {
     if (!isNaN(nb)) {
       nb = parseInt(nb);
       if (nb >= 0 && nb < attsNo) {
-        var url = atts[nb];
-        console.log('Attachment now open in browser');
-        open(url);
-        return;
+        const url = atts[nb].url;
+        const openInBrowser = () => {
+          console.log('Attachment now open in browser');
+          open(url);
+        }
+        if (atts[nb].type == 'photo') {
+          imgcat(url, {
+            log: true,
+            fallback: openInBrowser
+          });
+          return;
+        }
+        else {
+          return openInBrowser();
+        }
       }
     }
     console.log('Invalid attachment number, please try again'.cyan);


### PR DESCRIPTION
This adds imgcat support so that running `/view` on an attachment shows it inline if it is an image, and if you have imgcat support in your terminal (falling back to regular `open` otherwise).

Screenshot:
![17741063_10211376268715970_292717328_n](https://cloud.githubusercontent.com/assets/5315059/24563179/84ff2564-161b-11e7-8378-cf3ae0a8b4bf.png)
