### PR TITLE
Don't jump back to a conversation on new message if in a menu

### DIFF
--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -144,7 +144,6 @@ InteractiveCli.prototype.readPullMessage = function(message) {
       // Don't warn for current user messages (from another device)
       if (author.id != messenger.userId) {
         var headingData = heading.getData();
-        console.log('Heading data' + headingData);
         for (var i in headingData) {
           // Doesn't work when it's a group
           if (headingData[i].fbid == message.otherUserId || headingData[i].fbid == message.threadId) {
@@ -153,7 +152,10 @@ InteractiveCli.prototype.readPullMessage = function(message) {
         }
         // Moved this out of the for, in case we get a message from someone
         // not in the heading, we still need to refresh
-        interactive.printThread();
+        // ...but don't refresh if in the menu
+        if (recipientId != '') {
+          interactive.printThread();
+        }
       }
       return;
     }
@@ -200,6 +202,7 @@ InteractiveCli.prototype.handler = function(choice) {
     emitter.emit('getGroupConvos', current_userId, heading.getData(), function(data) {
       action = data.action;
       currentThreadCount = data.threadCount;
+      recipientId = '';
     });
     return;
   }
@@ -210,6 +213,7 @@ InteractiveCli.prototype.handler = function(choice) {
     emitter.emit('getConvos', current_userId, heading.getData(), function(data){
       action = data.action;
       currentThreadCount = data.threadCount;
+      recipientId = '';
     });
     group = false;
     return;
@@ -221,6 +225,7 @@ InteractiveCli.prototype.handler = function(choice) {
       action = data.action
       currentThreadCount = data.threadCount;
       group = true;
+      recipientId = '';
     });
     return;
   }


### PR DESCRIPTION
Steps to reproduce:
1. Enter conversation with someone
2. Type /menu to go back to the conversation list
3. Receive message from them

I would expect you to stay in the menu, but right now, you get sent back to the conversation. This change makes you stay in the menu.