### PR TITLE
Use readline for prompts

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node-notifier": "^1.0.0",
     "open": "0.0.5",
     "phantomjs-prebuilt": "^2.1.7",
+    "readline": "^1.3.0",
     "readline-sync": "^1.4.7",
     "request": "^2.72.0",
     "system": "^1.0.4"

--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -195,7 +195,7 @@ InteractiveCli.prototype.printThread = function(){
   // just show most recent visible lines
   var linesToWrite = lines.slice(x);
 
-  if (!Settings.getInstance().properties['preventMessageFlicker']) {
+  if (Settings.getInstance().properties['preventMessageFlicker']) {
     // erase content on the line from before
     linesToWrite = linesToWrite.map(ln => "\x1b[K" + ln)
   }

--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -110,7 +110,7 @@ InteractiveCli.prototype.initializeConversationViewFromFbid = function(id) {
   messenger.getLastMessage(recipientUrl, id, process.stdout.rows - 1, function(err, messages) {
     recipientId = id;
     interactive.threadHistory = [];
-    util.refreshConsole();
+    util.overwriteConsole();
     attsNo = 0;
     atts = [];
     for (var i in messages) {
@@ -173,7 +173,7 @@ InteractiveCli.prototype.readPullMessage = function(message) {
 };
 
 InteractiveCli.prototype.printThread = function(){
-  util.refreshConsole();
+  util.overwriteConsole();
   var w = process.stdout.columns - 1;
   var lines = [];
 
@@ -184,17 +184,17 @@ InteractiveCli.prototype.printThread = function(){
     }
   }
 
-  var x = 0;
-  if (lines.length > process.stdout.rows) {
-    x = lines.length + 1 + 1 /*header*/ + 3 /*some space*/ - process.stdout.rows;
-  }
+  var x = Math.max(0, lines.length - process.stdout.rows + 4);
 
   // Draw the header
   heading.writeHeader(this.currentConversationId);
 
-  for (; x < lines.length; ++x) {
-    console.log(lines[x]);
-  }
+  console.log(
+    lines
+      .slice(x) // just show most recent visible lines
+      .map(ln => "\x1b[K" + ln) // erase content on the line from before
+      .join("\n")
+  );
   rlInterface.prompt(true);
 };
 

--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -193,7 +193,7 @@ InteractiveCli.prototype.printThread = function(){
   // just show most recent visible lines
   var linesToWrite = lines.slice(x);
 
-  if (!Settings.getInstance().properties['disableColors']) {
+  if (!Settings.getInstance().properties['preventMessageFlicker']) {
     // erase content on the line from before
     linesToWrite = linesToWrite.map(ln => "\x1b[K" + ln)
   }

--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -14,6 +14,7 @@ var stdout = process.stdout;
 var crypt = new Crypt('password');
 const path = require('path');
 const notifier = require('node-notifier');
+const readline = require('readline');
 
 // 0 is select conversation, 1 is send message
 var action = 0;
@@ -29,6 +30,12 @@ var listeners = new Listeners();
 
 var atts = 0;
 var attsNo = [];
+
+const rlInterface = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: '> '
+});
 
 function InteractiveCli(){
   this.pull = new Pull();
@@ -188,6 +195,7 @@ InteractiveCli.prototype.printThread = function(){
   for (; x < lines.length; ++x) {
     console.log(lines[x]);
   }
+  rlInterface.prompt(true);
 };
 
 // TODO : remove early returns, use some sort of pattern
@@ -200,6 +208,7 @@ InteractiveCli.prototype.handler = function(choice) {
     emitter.emit('getGroupConvos', current_userId, heading.getData(), function(data) {
       action = data.action;
       currentThreadCount = data.threadCount;
+      rlInterface.prompt(true);
     });
     return;
   }
@@ -210,6 +219,7 @@ InteractiveCli.prototype.handler = function(choice) {
     emitter.emit('getConvos', current_userId, heading.getData(), function(data){
       action = data.action;
       currentThreadCount = data.threadCount;
+      rlInterface.prompt(true);
     });
     group = false;
     return;
@@ -221,6 +231,7 @@ InteractiveCli.prototype.handler = function(choice) {
       action = data.action
       currentThreadCount = data.threadCount;
       group = true;
+      rlInterface.prompt(true);
     });
     return;
   }
@@ -325,6 +336,7 @@ InteractiveCli.prototype.handler = function(choice) {
         emitter.emit('getConvos', current_userId, heading.getData(), function(data) {
           action = data.action;
           currentThreadCount = data.threadCount;
+          rlInterface.prompt(true);
         });
       }
     });
@@ -365,9 +377,12 @@ InteractiveCli.prototype.run = function(){
       emitter.emit('getConvos', current_userId, heading.getData(), function(data){
         action = data.action;
         currentThreadCount = data.threadCount;
+        rlInterface.prompt(true);
       });
 
-      stdin.addListener("data", interactive.handler);
+      rlInterface.on("line", interactive.handler);
+      rlInterface.on("close", interactive.exit);
+      rlInterface.prompt(true);
   });
 };
 

--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -5,6 +5,7 @@ var Pull = require('./pull.js');
 var Search = require('./search.js');
 var Listeners = require('./listeners.js');
 var Heading = require('./heading.js');
+var Settings = require('./settings.js');
 var open = require('open');
 
 var colors = require('colors');
@@ -189,12 +190,15 @@ InteractiveCli.prototype.printThread = function(){
   // Draw the header
   heading.writeHeader(this.currentConversationId);
 
-  console.log(
-    lines
-      .slice(x) // just show most recent visible lines
-      .map(ln => "\x1b[K" + ln) // erase content on the line from before
-      .join("\n")
-  );
+  // just show most recent visible lines
+  var linesToWrite = lines.slice(x);
+
+  if (!Settings.getInstance().properties['disableColors']) {
+    // erase content on the line from before
+    linesToWrite = linesToWrite.map(ln => "\x1b[K" + ln)
+  }
+
+  console.log(linesToWrite.join('\n'));
   rlInterface.prompt(true);
 };
 

--- a/scripts/listeners.js
+++ b/scripts/listeners.js
@@ -48,7 +48,7 @@ Listeners.prototype.getConversationsListener = function(userId, heading, cb) {
       threadCount: threads.length
     };
 
-    process.stdout.write("Select conversation : ");
+    console.log("Select conversation :");
     cb(data);
   });
 };
@@ -69,7 +69,7 @@ Listeners.prototype.getGroupConversationsListener = function(userId, heading, cb
         heading[i] = {fbid: thread.thread_fbid, name: thread.name, unread: 0};
     }
 
-    process.stdout.write("Select conversation : ");
+    console.log("Select conversation :");
 
     var data = {
       action: 0,

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -11,7 +11,8 @@ Settings = function() {
     instance = this;
     this.filename = '.settings';
     this.properties = {
-        disableColors: false
+        disableColors: false,
+        preventMessageFlicker: true
     };
 };
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -12,7 +12,7 @@ Settings = function() {
     this.filename = '.settings';
     this.properties = {
         disableColors: false,
-        preventMessageFlicker: true
+        preventMessageFlicker: false
     };
 };
 

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,3 +1,4 @@
+const Settings = require('./settings.js');
 const readline = require('readline');
 
 var Util = function(){};
@@ -7,7 +8,11 @@ Util.refreshConsole = function(){
 };
 
 Util.overwriteConsole = function(){
-  readline.cursorTo(process.stdout, 0, 0);
+  if (Settings.getInstance().properties['disableColors']) {
+    process.stdout.write('\033c');
+  } else {
+    readline.cursorTo(process.stdout, 0, 0);
+  }
 };
 
 module.exports = Util;

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,11 +1,13 @@
+const readline = require('readline');
+
 var Util = function(){};
 
 Util.refreshConsole = function(){
-  // var lines = process.stdout.getWindowSize()[1];
-  // for(var i = 0; i < lines; i++) {
-  //     console.log('\r\n');
-  // }
   process.stdout.write('\033c');
+};
+
+Util.overwriteConsole = function(){
+  readline.cursorTo(process.stdout, 0, 0);
 };
 
 module.exports = Util;

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -8,10 +8,10 @@ Util.refreshConsole = function(){
 };
 
 Util.overwriteConsole = function(){
-  if (Settings.getInstance().properties['disableColors']) {
-    process.stdout.write('\033c');
-  } else {
+  if (Settings.getInstance().properties['preventMessageFlicker']) {
     readline.cursorTo(process.stdout, 0, 0);
+  } else {
+    process.stdout.write('\033c');
   }
 };
 


### PR DESCRIPTION
Addresses https://github.com/Alex-Rose/fb-messenger-cli/issues/29

This uses Readline to replace the regular stdin prompt. Functionally, this means:
- when you receive a message in the middle of writing one, your text doesn't disappear
- you can use the arrow keys to move around in the message you are composing
- you can hit the up arrow to go through previous commands

Update: I also added a commit to remove flickering when receiving an incoming message. Instead of clearing the screen, then printing, I move the cursor to (0,0), then adding a clear-line escape sequence to the beginning of each line of the chat history, and print that all in one go.