### PR TITLE
Add /read command to mark conversation as read

### DIFF
--- a/scripts/interactive.js
+++ b/scripts/interactive.js
@@ -296,11 +296,12 @@ InteractiveCli.prototype.handler = function(choice) {
     console.log('/s[witch] # ....... Quick switch to conversation number #'.cyan);
     console.log('/search [query] ... Search your friends to chat'.cyan);
     console.log('/view # ........... View the attachment by the number given after the type'.cyan);
+    console.log('/read ............. Send a read receipt for this thread'.cyan);
     console.log('/help ............. Print this message'.cyan);
     return;
   }
 
-  else if(value.toLowerCase().indexOf('/search') != -1){
+  else if(value.toLowerCase().indexOf('/search') === 0){
     // Start a new search
     action = 2;
     // Take value on first space
@@ -313,6 +314,11 @@ InteractiveCli.prototype.handler = function(choice) {
     emitter.emit('startSearch', searchStr);
     return;
   }
+
+  else if (value.toLowerCase().indexOf('/read') === 0 && recipientId != '') {
+    emitter.emit('sendRead', recipientId);
+    return;
+  } 
 
   else if (value.indexOf('/') === 0) {
     console.log('Unknown command. Type /help for commands.'.cyan);
@@ -374,6 +380,7 @@ InteractiveCli.prototype.run = function(){
       emitter.on('sendMessage', listeners.sendMessageListener);
       emitter.on('getMessages', listeners.getMessagesListener);
       emitter.on('startSearch', listeners.searchListener);
+      emitter.on('sendRead', listeners.readListener);
 
       messenger.getFriends(function(friends) {
         var entry = {};

--- a/scripts/listeners.js
+++ b/scripts/listeners.js
@@ -102,6 +102,16 @@ Listeners.prototype.sendMessageListener = function(m, recipientId) {
 
 };
 
+Listeners.prototype.readListener = function(recipientId) {
+  messenger.markRead(recipientId, function(err) {
+    if(err) {
+      console.log('Read receipt did not send properly');
+    } else {
+      console.log('Marked conversation as read');
+    }
+  });
+}
+
 var printed = false;
 Listeners.prototype.searchListener = function(searchStr, choice, callback) {
   if(!printed) { // On first loop of search print choices

--- a/scripts/messenger.js
+++ b/scripts/messenger.js
@@ -177,6 +177,50 @@ Messenger.prototype.sendGroupMessage =  function (recipientId, body, callback) {
   });
 }
 
+// Mark a thread as read
+//   recipientId : Facebook numeric id of recipient. Can be a person or a thread
+// callback(err) does not get any data
+Messenger.prototype.markRead = function(recipientId, callback) {
+  const readURL = this.baseUrl + "/ajax/mercury/change_read_status.php?dpr=1";
+  const messenger = this;
+  const utcTimestamp = new Date().getTime();
+
+  request.post(readURL, {
+    headers: {
+      'origin': 'https://www.messenger.com',
+      'accept-encoding': 'gzip, deflate',
+      'x-msgr-region': 'ATN',
+      'accept-language': 'en-US,en;q=0.8',
+      'user-agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36',
+      'content-type': 'application/x-www-form-urlencoded',
+      'accept': '*/*',
+      'referer': readURL,
+      'cookie': messenger.cookie,
+      'authority': 'www.messenger.com'
+    },
+    formData: {
+      'watermarkTimestamp': utcTimestamp,
+      'shouldSendReadReceipt': 'true',
+      'commerce_last_message_type': '',
+      [`ids[${recipientId}]`]: 'true',
+      '__a':'1',
+      '__af':'iw',
+      '__req':'19',
+      '__be':'-1',
+      '__pc':'PHASED:messengerdotcom_pkg',
+      'fb_dtsg': messenger.fbdtsg,
+      'ttstamp':'265817010265545710511657711165865817157112577010611183120110',
+      '__rev':'2947488'
+    }
+  }, function(err, httpResponse, body) {
+    if (err) {
+      callback(err);
+    } else {
+      callback();
+    }
+  });
+};
+
 Messenger.prototype.getLastMessage = function(recipient, recipientId, count, callback) {
   var messenger = this;
   var recipientUrl = this.baseUrl + "/t/" + recipient;


### PR DESCRIPTION
Normally I like the behaviour of not sending read receipts, but it's convenient to be able to send one to clear the notification on Facebook for that chat thread. This adds a `/read` command to mark a thread as read, which is visible to other members of the chat and clears the notification.