### PR TITLE
Displays friendly login message

### DIFF
--- a/scripts/login.js
+++ b/scripts/login.js
@@ -13,6 +13,8 @@ Login.prototype.execute = function(callback) {
   result.email = readlineSync.question('Email: ');
   result.password = readlineSync.question('Password: ', {hideEchoBack: true});
 
+  console.log("Attempting login...");
+
   var arguments = [path.resolve(__dirname, 'phantom.js'), result.email, result.password];
 
   phantom = new login.run_cmd( phantomjs.path, arguments, function () {


### PR DESCRIPTION
Sometimes the time it takes for phantomjs to log you in after you enter the password is a bit long, especially for weak internet connections like mine.

This simply prints "Attempting login..." so that the user knows something's going on behind-the-scenes.