### PR TITLE
Package.json fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.8.1",
   "description": "An interface for facebook communications through the cli",
   "author": "Alexandre Rose and Samuel Bergeron",
-  "repository": "http://github.com/Alex-Rose/fb-messenger-cli",
   "license": "MIT",
   "repository": "http://github.com/Alex-Rose/fb-messenger-cli",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.8.1",
   "description": "An interface for facebook communications through the cli",
   "author": "Alexandre Rose and Samuel Bergeron",
+  "repository": "http://github.com/Alex-Rose/fb-messenger-cli",
   "license": "MIT",
   "repository": "http://github.com/Alex-Rose/fb-messenger-cli",
   "dependencies": {
@@ -18,8 +19,11 @@
     "system": "^1.0.4"
   },
   "devDependencies": {
-    "mocha": "2.4.x",
+    "mocha": "3.5.x",
     "chai": "3.5.x"
+  },
+  "engines": {
+    "node": ">=6.0"
   },
   "bin": {
     "fb-messenger-cli": "cli.js"


### PR DESCRIPTION
Addresses warnings during `npm install` as mentioned in #101.
- The `crypto` package is no longer a third-party package, and has been integrated into node, so it doesn't need to be a separate dependency.
- Added the repository URL.
- Updated node to 6.x (LTS).
- Updated mocha to 3.5.x to remove warning messages.