### PR TITLE
Null check for empty body

### DIFF
--- a/scripts/messenger.js
+++ b/scripts/messenger.js
@@ -236,6 +236,9 @@ Messenger.prototype.getMessages = function(recipient, recipientId, count, callba
   options.formData[limitString] = count;
 
   request.post(options, function(err, response, body){
+        if(!body) {
+          callback(err, []);
+        }
         body = messenger.cleanJson(body);
         let json = JSON.parse(body);
         let payload = json['payload'];


### PR DESCRIPTION
Sometimes on a weak connection the request returns a null/empty body, which causes the app to crash. This is a simple workaround to default to the existing fallback behavior.