### PR TITLE
Test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ Then ``fb-messenger-cli`` from anywhere
 4. Develop away
 
 ### Running tests
-1. ``cd`` into the test directory
-2. Mocha should be installed with the dev dependencies
-3. Run ``mocha regression.js``**
+1. Mocha should be installed with the dev dependencies
+2. Run ``npm run test`` **
 
 ** Make sure you've logged in to the cli at least once before running the tests. Regression.js uses your log-in to test the sending and receiving features
 

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "bin": {
     "fb-messenger-cli": "cli.js"
+  },
+  "scripts": {
+    "test": "node_modules/mocha/bin/mocha scripts/test/*"
   }
 }

--- a/scripts/messenger.js
+++ b/scripts/messenger.js
@@ -65,6 +65,7 @@ Messenger.prototype.cleanGraphQl = function (body) {
 // Parses a list of conversation participants into users
 // Useful for adding users that are not "friends" to our database
 Messenger.prototype.saveParticipantsAsFriends = function (participants) {
+  let messenger = this;
   for (let i = 0; i < participants.length; i++) {
     // Add only the ones we don't already have
     if(participants[i].is_friend !== 'true') {

--- a/scripts/test/regression.js
+++ b/scripts/test/regression.js
@@ -44,6 +44,11 @@ describe('Crypt', function() {
   });
 });
 
+// Constants for testing
+const testUser = 'ar.alexandre.rose';
+const testUserId = '731419306';
+const testMessage = 'Running tests - Send message'
+
 describe('Messenger', function() {
   var json;
   var messenger;
@@ -73,17 +78,32 @@ describe('Messenger', function() {
     // Allow more time for network calls
     this.timeout(5000);
 
-    messenger.sendMessage('ar.alexandre.rose', '731419306', 'Running tests - Send message', done);
+    messenger.sendMessage(testUser, testUserId, testMessage, done);
   });
 
-  it('GetLastMessage', function(done) {
+  it('Get last 10 messages', function(done) {
     // Allow more time for network calls
-    this.timeout(5000);
+    this.timeout(20000);
 
-    messenger.getMessages('ar.alexandre.rose', '731419306', 10, function(err, messages) {
-      expect(messages.length).is.equal(10);
-      done();
-    });
+    function finished() {
+      messenger.getMessages(testUser, testUserId, 10, function(err, messages) {
+        expect(messages.length).is.equal(10);
+        done();
+      });
+    }
+
+    // Ensure that there are at least 10 messages in the conversation
+    function sender(i) {
+      if(i < 11) {
+        messenger.sendMessage(testUser, testUserId, testMessage, function(err) {
+          expect(err).to.not.be.ok;
+          sender(i+1);
+        });
+      } else {
+        finished();
+      }
+    }
+    sender(0);
   });
 
   it('Get threads', function(done) {


### PR DESCRIPTION
The test suite wasn't passing, so I added some fixes to two of the Messenger tests. I also added a script in the package.json so it's easy to run the tests.

One thought I had is that right now it looks like we're using Alex Rose's account as a test receiver for the messages; would it be possible to look into maybe using a Facebook test account to receive messages? Just a thought so we don't clog up Alex's inbox every time we run a test!