### PR TITLE
Clear console when loading conversations page

### DIFF
--- a/scripts/listeners.js
+++ b/scripts/listeners.js
@@ -55,7 +55,7 @@ class Listeners {
                 process.exit(1);
             }
 
-            refreshConsole();
+            refreshConsole(true);
             this.options = {};
 
             threads.sort((a, b) => b.timestamp - a.timestamp);

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -1,8 +1,8 @@
 const Settings = require('./settings.js');
 const readline = require('readline');
 
-function refreshConsole () {
-    if (Settings.properties.preventMessageFlicker) {
+function refreshConsole (force = false) {
+    if (!force && Settings.properties.preventMessageFlicker) {
         readline.cursorTo(process.stdout, 0, 0);
     } else {
         process.stdout.write('\033c');


### PR DESCRIPTION
With the 'prevent flicker' option on, navigating from a thread back to the conversations page causes long lines from the thread to stay "backgrounded" 

This PR adds an optional boolean parameter to refreshConsole that can force a console clear, and uses that functionality when refreshConsole is called for loading conversations