### PR TITLE
login: use chromium with --no-sandbox option

### DIFF
--- a/scripts/login.js
+++ b/scripts/login.js
@@ -31,7 +31,7 @@ class Login {
 
     getCookie() {
         let page;
-        return puppeteer.launch({headless: this.headless}).then(browser => {
+        return puppeteer.launch({headless: this.headless, args: ['--no-sandbox', '--disable-setuid-sandbox']}).then(browser => {
             this.browser = browser;
             return this.browser.pages();
         }).then(promisedPage => {


### PR DESCRIPTION
Fix https://github.com/Alex-Rose/fb-messenger-cli/issues/143

Not sure this is the recommended way from reading https://github.com/Googlechrome/puppeteer/issues/290 but it seems more and more projects do that and it fixed the issue for me on `4.14.12-1-ARCH` and `node v9.3.0`.