### PR TITLE
Fix handling image attachments and animated images in current conversation

### DIFF
--- a/scripts/pull.js
+++ b/scripts/pull.js
@@ -153,6 +153,15 @@ class Pull extends EventEmitter {
                                                         });
                                                     }
                                                 }
+                                            } else if (att.mercury.blob_attachment.__typename === 'MessageImage') {
+                                                this.emit('message', {
+                                                    type: 'msg',
+                                                    author: ms.delta.messageMetadata.actorFbId,
+                                                    otherUserId: ms.delta.messageMetadata.threadKey.otherUserFbId,
+                                                    threadId: ms.delta.messageMetadata.threadKey.threadFbId,
+                                                    timestamp: ms.delta.messageMetadata.timestamp,
+                                                    attachment: att.mercury.blob_attachment
+                                                });
                                             }
                                         }
                                     } else if (ms.delta.class === 'AdminTextMessage') {

--- a/scripts/pull.js
+++ b/scripts/pull.js
@@ -157,6 +157,17 @@ class Pull extends EventEmitter {
                                                 this.emit('message', {
                                                     type: 'msg',
                                                     author: ms.delta.messageMetadata.actorFbId,
+                                                    body: 'sent an image ',
+                                                    otherUserId: ms.delta.messageMetadata.threadKey.otherUserFbId,
+                                                    threadId: ms.delta.messageMetadata.threadKey.threadFbId,
+                                                    timestamp: ms.delta.messageMetadata.timestamp,
+                                                    attachment: att.mercury.blob_attachment
+                                                });
+                                            } else if (att.mercury.blob_attachment.__typename === 'MessageAnimatedImage') {
+                                                this.emit('message', {
+                                                    type: 'msg',
+                                                    author: ms.delta.messageMetadata.actorFbId,
+                                                    body: 'sent a gif ',
                                                     otherUserId: ms.delta.messageMetadata.threadKey.otherUserFbId,
                                                     threadId: ms.delta.messageMetadata.threadKey.threadFbId,
                                                     timestamp: ms.delta.messageMetadata.timestamp,


### PR DESCRIPTION
Image attachments and animated images would fail to show any message indication when conversation is open despite successfully showing when the conversation is refreshed/reopened.

This adds extra filters for these message types 