### PR TITLE
fix for ReferenceError: https://github.com/Alex-Rose/fb-messenger-cli/issues/153

### DIFF
--- a/scripts/login.js
+++ b/scripts/login.js
@@ -167,8 +167,9 @@ class Login {
     }
 
     _onPageLoad(is2FA) {
+	let page;
         return this.browser.pages().then(pages => {
-            const page = pages[0];
+            page = pages[0];
             return page.cookies();
         }).then(cookies => {
             return this._getAuthCookie(cookies);


### PR DESCRIPTION
Having fixed this, it's possible that there are still some timing issues with logging in, as the timeout before closing Chrome is a little on the short side, especially when dealing with the 'Was this you?' pages Facebook throws up.