### PR TITLE
Add ability to limit number of messages shown in a conversation

### DIFF
--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -315,10 +315,10 @@ InteractiveCli.prototype.printThread = function(){
     const w = process.stdout.columns - 1;
     const lines = [];
 
-	const totalLines = interactive.threadHistory.length;
-	const linesToShow = Settings.properties.threadLineLimit > 0
-		? Math.min(totalLines, Settings.properties.threadLineLimit)
-		: totalLines;
+    const totalLines = interactive.threadHistory.length;
+    const linesToShow = Settings.properties.threadLineLimit > 0
+        ? Math.min(totalLines, Settings.properties.threadLineLimit)
+        : totalLines;
 
     for (let i = totalLines - linesToShow; i < totalLines; ++i) {
         const ln = interactive.threadHistory[i].match(new RegExp(`.{1,${  w  }}`, 'g'));
@@ -468,9 +468,9 @@ InteractiveCli.prototype.handleCommands = function(command) {
                     Settings.save();
                     console.log('Changed the line limit settings!'.cyan);
                     rlInterface.prompt(true);
-					if (action === 1) {
-					    interactive.handleCommands("/refresh");
-					}
+                    if (action === 1) {
+                        interactive.handleCommands("/refresh");
+                    }
                     break;
                 }
             }
@@ -479,13 +479,13 @@ InteractiveCli.prototype.handleCommands = function(command) {
             break;
         case '/nolimit':
             Settings.properties.threadLineLimit = -1;
-			Settings.save();
-			console.log('Unset the line limit setting!'.cyan);
-			rlInterface.prompt(true);
-			if (action === 1) {
+            Settings.save();
+            console.log('Unset the line limit setting!'.cyan);
+            rlInterface.prompt(true);
+            if (action === 1) {
                 interactive.handleCommands("/refresh");
-			}
-			break;
+            }
+            break;
 
         default:
             console.log('Unknown command. Type /help for commands.'.cyan);

--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -315,7 +315,12 @@ InteractiveCli.prototype.printThread = function(){
     const w = process.stdout.columns - 1;
     const lines = [];
 
-    for (let i = 0; i < interactive.threadHistory.length; ++i) {
+	const totalLines = interactive.threadHistory.length;
+	const linesToShow = Settings.properties.threadLineLimit > 0
+		? Math.min(totalLines, Settings.properties.threadLineLimit)
+		: totalLines;
+
+    for (let i = totalLines - linesToShow; i < totalLines; ++i) {
         const ln = interactive.threadHistory[i].match(new RegExp(`.{1,${  w  }}`, 'g'));
         for (const j in ln) {
             lines.push(ln[j]);
@@ -423,6 +428,8 @@ InteractiveCli.prototype.handleCommands = function(command) {
             console.log('/v /view [#] ...... View the attachment by the number given after the type'.cyan);
             console.log('/r /refresh ....... Refresh the current converation'.cyan);
             console.log('/timestamp ........ Toggle timestamp for messages'.cyan);
+            console.log('/linelimit [#] .... Set max number of messages to display in a conversation'.cyan);
+            console.log('/nolimit .......... Unset a line limit, display all available messages'.cyan);
             console.log('/help ............. Print this message'.cyan);
             rlInterface.prompt(true);
             break;
@@ -451,6 +458,34 @@ InteractiveCli.prototype.handleCommands = function(command) {
 
             interactive.handleCommands("/refresh");
             break;
+        case '/linelimit':
+            let lim = options[1];
+
+            if (!isNaN(lim)) {
+                lim = parseInt(lim);
+                if (lim >= 0) {
+                    Settings.properties.threadLineLimit = lim;
+                    Settings.save();
+                    console.log('Changed the line limit settings!'.cyan);
+                    rlInterface.prompt(true);
+					if (action === 1) {
+					    interactive.handleCommands("/refresh");
+					}
+                    break;
+                }
+            }
+            console.log('Invalid line limit setting, please try again'.cyan);
+            rlInterface.prompt(true);
+            break;
+        case '/nolimit':
+            Settings.properties.threadLineLimit = -1;
+			Settings.save();
+			console.log('Unset the line limit setting!'.cyan);
+			rlInterface.prompt(true);
+			if (action === 1) {
+                interactive.handleCommands("/refresh");
+			}
+			break;
 
         default:
             console.log('Unknown command. Type /help for commands.'.cyan);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -16,6 +16,7 @@ class Settings {
             preventMessageFlicker: false,
             desktopNotifications: false,
             showTimestamps: false,
+            threadLineLimit: -1,
             useCustomNicknames: true,
             timestampLocale: "en-US",
             timestampOptions: {},


### PR DESCRIPTION
The reason I wanted to use a CLI for messenger was to be more private and not let people looking at my screen see as much of my conversations. All this feature does is allow people to say that they only want to see the first [n] most recent messages in a conversation rather than all available messages.

I had trouble running the regression tests but I tested it out by hand on my own. 