### PR TITLE
Update sticker handling

### DIFF
--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -103,6 +103,17 @@ function renderMessage(author, message) {
     if (message.body !== undefined && message.body !== "")
         msg += message.body;
 
+    if (message.sticker) {
+        const x = `${attsNo}`;
+
+        const label = message.sticker.label
+            ? message.sticker.label
+            : 'sticker';
+
+        msg += `${' [ '.red + label } ${  x.cyan  }${' ]'.red}`;
+        attsNo++;
+	}
+
     if (message.attachmentsLegacy) {
         for (let i = 0; i < message.attachmentsLegacy.length; i++) {
             const a = message.attachmentsLegacy[i];

--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -112,7 +112,7 @@ function renderMessage(author, message) {
 
         msg += `${' [ '.red + label } ${  x.cyan  }${' ]'.red}`;
         attsNo++;
-	}
+    }
 
     if (message.attachmentsLegacy) {
         for (let i = 0; i < message.attachmentsLegacy.length; i++) {

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -254,7 +254,7 @@ class Messenger {
                         const m = msg[i];
                         const obj = {
                             'author': m.author,
-                            'body': m.message ? m.message.text : m.snippet,
+                            'body': m.body,
                             'other_user_fbid': m.other_user_fbid,
                             'thread_fbid': m.thread_fbid,
                             'timestamp': m.timestamp,

--- a/lib/messenger.js
+++ b/lib/messenger.js
@@ -254,7 +254,7 @@ class Messenger {
                         const m = msg[i];
                         const obj = {
                             'author': m.author,
-                            'body': m.body,
+                            'body': m.message ? m.message.text : m.snippet,
                             'other_user_fbid': m.other_user_fbid,
                             'thread_fbid': m.thread_fbid,
                             'timestamp': m.timestamp,
@@ -328,14 +328,21 @@ class Messenger {
                         if (messages !== undefined) {
                             for (const message in messages) {
                                 const m = messages[message];
+                                const text = m.sticker || !m.message
+                                    ? m.snippet
+                                    : m.message.text;
 
                                 const obj = {
                                     'author': m.message_sender.id,
-                                    'body': m.message ? m.message.text : m.snippet,
+                                    'body': text,
                                     'other_user_fbid': thread.thread_key.other_user_fbid,
                                     'thread_fbid': thread.thread_key.thread_fbid,
                                     'timestamp': m.timestamp_precise
                                 };
+
+                                if (m.sticker) {
+                                    obj.sticker = m.sticker;
+                                }
 
                                 if (m.extensible_attachment)
                                     obj.storyAttachment = m.extensible_attachment.story_attachment;

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -102,7 +102,6 @@ class Pull extends EventEmitter {
 
                             for (const j in message.ms) {
                                 const ms = message.ms[j];
-                                // console.log(ms.type);
                                 if (ms.type === 'delta' && ms.delta !== undefined) {
                                     if (ms.delta.class === 'NewMessage') {
                                         if (ms.delta.body !== undefined) {
@@ -125,17 +124,18 @@ class Pull extends EventEmitter {
                                                     threadId: ms.delta.messageMetadata.threadKey.threadFbId,
                                                     timestamp: ms.delta.messageMetadata.timestamp
                                                 });
-                                            } else if (att.mercury.attach_type === 'sticker') {
-                                                let body = 'sent a sticker';
+                                            } else if (ms.delta.stickerId !== undefined) {
+                                                let text = 'Sent a sticker.';
                                                 if (att.mercury.metadata !== undefined && att.mercury.metadata.accessibilityLabel !== undefined) {
                                                     body += `: ${  att.mercury.metadata.accessibilityLabel}`;
                                                 }
                                                 this.emit('message', {
                                                     type: 'msg',
                                                     author: ms.delta.messageMetadata.actorFbId,
-                                                    body: body,
+                                                    body: text,
+                                                    sticker: ms.delta.attachments[0].mercury.sticker_attachment,
                                                     otherUserId: ms.delta.messageMetadata.threadKey.otherUserFbId,
-                                                    threadId: ms.delta.messageMetadata.threadKey.otherUserFbId,
+                                                    threadId: ms.delta.messageMetadata.threadKey.threadFbId,
                                                     timestamp: ms.delta.messageMetadata.timestamp
                                                 });
                                             } else if (att.mercury.attach_type === 'share') {
@@ -148,7 +148,7 @@ class Pull extends EventEmitter {
                                                             author: ms.delta.messageMetadata.actorFbId,
                                                             body: body,
                                                             otherUserId: ms.delta.messageMetadata.threadKey.otherUserFbId,
-                                                            threadId: ms.delta.messageMetadata.threadKey.otherUserFbId,
+                                                            threadId: ms.delta.messageMetadata.threadKey.threadFbId,
                                                             timestamp: ms.delta.messageMetadata.timestamp
                                                         });
                                                     }

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -127,7 +127,7 @@ class Pull extends EventEmitter {
                                             } else if (ms.delta.stickerId !== undefined) {
                                                 let text = 'Sent a sticker.';
                                                 if (att.mercury.metadata !== undefined && att.mercury.metadata.accessibilityLabel !== undefined) {
-                                                    body += `: ${  att.mercury.metadata.accessibilityLabel}`;
+                                                    text += `: ${  att.mercury.metadata.accessibilityLabel}`;
                                                 }
                                                 this.emit('message', {
                                                     type: 'msg',


### PR DESCRIPTION
I noticed that when I when I was logged in and someone sent me a sticker, no hint of a new message appeared on the screen. Upon starting up or refreshing, stickers appeared as a blank message line. I send and receive a lot of stickers, so this kind of bugged me. This change updates the handling of stickers to display the message snippet as well as a description of the sticker, if available.