### PR TITLE
Use XDG_CONFIG_HOME to store the config files [fix #189]

### DIFF
--- a/lib/crypt.js
+++ b/lib/crypt.js
@@ -8,6 +8,8 @@ class Crypt {
         this.filename = '.kryptonite';
         this.data = undefined;
         this.password = 'password';
+        this.confDir = process.env.XDG_CONFIG_HOME || path.resolve(process.env.HOME, '.config')
+        this.confDir = path.resolve(this.confDir, 'fb-messenger-cli')
     }
 
     setPassword(pw) {
@@ -34,14 +36,17 @@ class Crypt {
 
     save(data) {
         const encrypted = this.encrypt(data);
-        const savePath = path.resolve(__dirname, '../', this.filename);
+        const savePath = path.resolve(this.confDir, this.filename);
+        if (!fs.existsSync(this.confDir)){
+            fs.mkdirSync(this.confDir);
+        }
         fs.writeFileSync(savePath, encrypted);
     }
 
     load(callback) {
         if (!this.data) {
-            fs.readFile(path.resolve(__dirname, '../', this.filename), (err, data) => {
-                if (err) {
+            fs.readFile(path.resolve(this.confDir, this.filename), (err, data) => {
+                if(err) {
                     callback('No saved profile, please login');
                 } else {
                     this.decrypt(data.toString(), (err, dec) => {
@@ -61,7 +66,7 @@ class Crypt {
 
     flush() {
         this.data = undefined;
-        fs.unlink(path.resolve(__dirname, '../', this.filename), (err) => {
+        fs.unlink(path.resolve(this.confDir, this.filename), (err) => {
             err('Error while logging out')
         });
     }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -8,7 +8,9 @@ const path = require('path');
 class Settings {
     constructor () {
         this.filename = '.settings';
-        this.path = path.resolve(__dirname, '../', this.filename);
+        this.confDir = process.env.XDG_CONFIG_HOME || path.resolve(process.env.HOME, '.config')
+        this.confDir = path.resolve(this.confDir, 'fb-messenger-cli')
+        this.path = path.resolve(this.confDir, this.filename);
         this.properties = {
             disableColors: false,
             groupColors: true,
@@ -29,6 +31,9 @@ class Settings {
 
     // Save the current properties dictionary on disk
     save() {
+        if (!fs.existsSync(this.confDir)){
+            fs.mkdirSync(this.confDir);
+        }
         fs.writeFile(this.path, JSON.stringify(this.properties, null, '  '), (err) => {
             if (!err) {
                 console.log('Settings have been saved');
@@ -41,7 +46,7 @@ class Settings {
     // Load previously saved properties from disk
     // callback(error, properties), where properties is a dictionary
     read(callback) {
-        fs.readFile(path.resolve(__dirname, '../', this.filename), (err, data) => {
+        fs.readFile(path.resolve(this.confDir, this.filename), (err, data) => {
             if (!err) {
                 try {
                     const fileProperties = JSON.parse(data.toString());


### PR DESCRIPTION
This change makes it so .settings and .kryptonite are now saved under
$XDG_CONFIG_HOME/fb-messenger-cli or $HOME/.config/fb-messenger-cli if
XDG_CONFIG_HOME isn't set. This allows to use the program without root
access even when the program is installed system wide.