### PR TITLE
Local user gets their own color instead of white

### DIFF
--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -59,8 +59,11 @@ function getDisplayName(author) {
 
     if(!author) author = { name: 'unknown' };
 
-    if(currentConversation && currentConversation.isGroup && Settings.properties.groupColors) {
-        colorPosition = author.name.length % colorList.length; 
+    if(currentConversation && Settings.properties.groupColors) {
+        if (currentConversation.isGroup)
+            colorPosition = author.name.length % colorList.length; 
+        else if (author.id === messenger.userId)
+                colorPosition = 1;
     }
 	
     let displayName;	
@@ -68,11 +71,7 @@ function getDisplayName(author) {
         displayName = author.name;
     } else displayName = author.custom_nickname || author.name;
   
-    if (author.id === messenger.userId)
-        return displayName;
-    else {
-        return colorList[colorPosition](displayName);
-    }
+    return colorList[colorPosition](displayName);
 }
 
 function renderMessage(author, message) {


### PR DESCRIPTION
Updated getDisplayName() to help distinguish where messages start when the fb-messenger-cli user writes consecutive messages that all wrap around the screen.