### PR TITLE
Add dotfiles to user directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ phantomjs.exe
 
 ## Don't commit settings past default ones
 .settings
+
+## Don't commit any encryption/settings files
+.fbmessenger*
+test.*

--- a/cli.js
+++ b/cli.js
@@ -22,7 +22,7 @@
     function verifyLogon(callback) {
         crypt.load((cryptLoadErr, data) => {
             // Load settings before performing any other actions
-            Settings.read((readSettingsErr) => {
+            Settings.read((readSettingsErr, settings) => {
                 if (readSettingsErr) {
                     callback(readSettingsErr);
                 }

--- a/lib/crypt.js
+++ b/lib/crypt.js
@@ -1,11 +1,13 @@
 const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { getDataDirectory } = require('./data_directory');
 
 class Crypt {
     constructor() {
         this.algorithm = 'aes-256-ctr';
-        this.filename = '.kryptonite';
+        this.filename = '.fbmessenger.enc';
+        this.filepath = path.resolve(getDataDirectory(), this.filename);
         this.data = undefined;
         this.password = 'password';
     }
@@ -34,20 +36,19 @@ class Crypt {
 
     save(data) {
         const encrypted = this.encrypt(data);
-        const savePath = path.resolve(__dirname, '../', this.filename);
-        fs.writeFileSync(savePath, encrypted);
+        fs.writeFileSync(this.filepath, encrypted);
     }
 
     load(callback) {
         if (!this.data) {
-            fs.readFile(path.resolve(__dirname, '../', this.filename), (err, data) => {
+            fs.readFile(this.filepath, (err, data) => {
                 if (err) {
                     callback('No saved profile, please login');
                 } else {
                     this.decrypt(data.toString(), (err, dec) => {
-                        if (err)
+                        if (err) {
                             callback(err);
-                        else {
+                        } else {
                             this.data = dec;
                             callback(null, this.data);
                         }
@@ -61,7 +62,7 @@ class Crypt {
 
     flush() {
         this.data = undefined;
-        fs.unlink(path.resolve(__dirname, '../', this.filename), (err) => {
+        fs.unlink(this.filepath, (err) => {
             err('Error while logging out')
         });
     }

--- a/lib/data_directory.js
+++ b/lib/data_directory.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const normalizeFilePath = filePath => {
+  if (typeof filePath !== 'string') {
+    throw new TypeError(`Expected a string, got ${typeof filePath}`);
+  }
+
+  const homeDirectory = os.homedir();
+
+  if (homeDirectory) {
+    return filePath.replace(/^~(?=$|\/|\\)/, homeDirectory);
+  }
+
+  return filePath;
+};
+
+const getDataDirectory = () => {
+  const environmentDataDirectory = process.env.FB_MESSENGER_DATA_DIR;
+  const homeDirectory = os.homedir();
+  const thisDirectory = path.resolve(__dirname, '../');
+
+  if (environmentDataDirectory) {
+    return normalizeFilePath(environmentDataDirectory);
+  }
+
+  if (homeDirectory) {
+    return homeDirectory;
+  }
+
+  return thisDirectory;
+};
+
+module.exports = {
+  getDataDirectory,
+};

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -4,11 +4,12 @@
 
 const fs = require('fs');
 const path = require('path');
+const { getDataDirectory } = require('./data_directory');
 
 class Settings {
     constructor () {
-        this.filename = '.settings';
-        this.path = path.resolve(__dirname, '../', this.filename);
+        this.filename = '.fbmessengerrc';
+        this.filepath = path.resolve(getDataDirectory(), this.filename);
         this.properties = {
             disableColors: false,
             groupColors: true,
@@ -29,11 +30,11 @@ class Settings {
 
     // Save the current properties dictionary on disk
     save() {
-        fs.writeFile(this.path, JSON.stringify(this.properties, null, '  '), (err) => {
+        fs.writeFile(this.filepath, JSON.stringify(this.properties, null, '  '), (err) => {
             if (!err) {
                 console.log('Settings have been saved');
             } else {
-                console.log(`Error saving .settings file: ${err}`);
+                console.log(`Error saving ${this.filepath} file: ${err}`);
             }
         });
     }
@@ -41,7 +42,7 @@ class Settings {
     // Load previously saved properties from disk
     // callback(error, properties), where properties is a dictionary
     read(callback) {
-        fs.readFile(path.resolve(__dirname, '../', this.filename), (err, data) => {
+        fs.readFile(this.filepath, (err, data) => {
             if (!err) {
                 try {
                     const fileProperties = JSON.parse(data.toString());
@@ -54,8 +55,11 @@ class Settings {
                         else diff = true;
                     });
 
-                    if (diff) this.save();
+                    if (diff) {
+                        this.save();
+                    }
 
+                    return callback(null, fileProperties);
                 } catch (parseErr) {
                     this.save();
                     return callback('Warning: Settings are invalid, saving default values');
@@ -64,13 +68,12 @@ class Settings {
                 this.save();
                 return callback('Warning: Settings not found, saving default values');
             }
-            callback();
         });
     }
 
     // Delete properties from disk and wipe dictionary in memory
     flush() {
-        fs.unlink(this.filename);
+        fs.unlink(this.filepath);
         this.properties = {};
     }
 

--- a/lib/test/regression.js
+++ b/lib/test/regression.js
@@ -6,37 +6,39 @@ const Crypt = require('../crypt.js');
 const Messenger = require('../messenger.js');
 const Settings = require('../settings.js');
 const path = require('path');
+const oldCryptFilename = Crypt.filename;
+const oldCryptFilepath = Crypt.filepath;
 
 describe('Crypt', () => {
-    it('getInstance() should create a new singleton object', () => {
-        const crypt = Crypt.getInstance();
-        expect(crypt).to.not.equal(undefined);
+    before(() => {
+        const filename = 'test.fbmessenger.enc';
+        Crypt.filename = filename;
+        Crypt.filepath = path.resolve('.', filename);
     });
 
-    it('getInstance() always returns the same instance', () => {
-        let crypt = Crypt.getInstance();
-        crypt.password = 'test123_%';
-        crypt = Crypt.getInstance();
-        expect(crypt.password).to.equal('test123_%');
+    afterEach(() => {
+        Crypt.data = undefined;
+    });
+
+    after(() => {
+        Crypt.filename = oldCryptFilename;
+        Crypt.filepath = oldCryptFilepath;
     });
 
     it('encrypt() and decrypt() should return original data', () => {
         const data = "{some: 'things', are: 'not equal'}";
-        const crypt = Crypt.getInstance();
-        const encrypted = crypt.encrypt(data);
-        const decrypted = crypt.decrypt(encrypted);
-        expect(decrypted).to.equal(data);
+        const encrypted = Crypt.encrypt(data);
+        Crypt.decrypt(encrypted, (_err, decrypted) => {
+            expect(decrypted).to.equal(data);
+        });
     });
 
     it('save() and load()', (done) => {
-        const crypt = Crypt.getInstance();
-        const file = '.test_kryptonite';
         const data = JSON.stringify({theTest: 'data', is: 5012344});
 
-        crypt.filename = file;
-        crypt.save(data);
+        Crypt.save(data);
 
-        crypt.load((err, result) => {
+        Crypt.load((err, result) => {
             expect(result).to.equal(data);
             done();
         });
@@ -48,15 +50,14 @@ describe('Messenger', () => {
     let json;
     let messenger;
 
+    afterEach(() => {
+        Crypt.data = undefined;
+    });
+
     it('Load cookie', (done) => {
-    // Reset crypt
-        const crypt = new Crypt();
-        crypt.filename = '.kryptonite';
-
-        crypt.load((err, result) => {
-
+        // Reset crypt
+        Crypt.load((err, result) => {
             expect(() => {JSON.parse(result);}).not.throw(Error);
-
             json = JSON.parse(result);
             expect(json.cookie).to.not.equal.undefined;
             expect(json.fb_dtsg).to.not.equal.undefined;
@@ -65,61 +66,81 @@ describe('Messenger', () => {
         });
     });
 
-    it('Create Messenger', () => {
-        messenger = new Messenger(json.cookie, json.c_user, json.fb_dtsg);
-    });
-
-    it('Send message', function(done) {
-    // Allow more time for network calls
-        this.timeout(5000);
-
-        messenger.sendMessage('ar.alexandre.rose', '731419306', 'Running tests - Send message', done);
-    });
-
-    it('GetLastMessage', function(done) {
-    // Allow more time for network calls
-        this.timeout(5000);
-
-        messenger.getMessages('ar.alexandre.rose', '731419306', 10, (err, messages) => {
-            expect(messages.length).is.equal(10);
-            done();
+    describe('when data is loaded from the cookie', () => {
+        beforeEach(() => {
+            Crypt.load((err, data) => {
+                json = JSON.parse(data);
+            });
         });
-    });
 
-    it('Get threads', function(done) {
-    // Allow more time for network calls
-        this.timeout(5000);
+        it('Create Messenger', () => {
+            messenger = new Messenger(json.cookie, json.c_user, json.fb_dtsg);
+        });
 
-        messenger.getThreads(true, done);
+        it('getFriends', function(done) {
+            // Set a higher timeout for network calls
+            this.timeout(5000);
+            messenger.getFriends((_err, friends) => {
+                const friendIds = Object.keys(friends);
+                expect(friendIds.length).to.be.above(1);
+                done();
+            });
+        });
+
+        it('Get threads', function (done) {
+            // Allow more time for network calls
+            this.timeout(5000);
+
+            messenger.getThreads((_err, messages) => {
+                expect(messages.length).to.be.above(1);
+                done();
+            });
+        });
+
+        describe('interacting with friends', () => {
+            it('Send message', function (done) {
+                // Allow more time for network calls
+                this.timeout(5000);
+
+                messenger.getFriends((_, friends) => {
+                    const myself = friends[json.c_user];
+                    messenger.sendMessage(myself.vanity, myself.id, 'Running tests - Send message', done);
+                });
+            });
+
+            it('GetLastMessage', function (done) {
+                // Set a higher timeout for network calls
+                this.timeout(5000);
+                messenger.getFriends((_, friends) => {
+                    const myself = friends[json.c_user];
+
+                    messenger.getMessagesGraphQl(myself.vanity, myself.id, 10, (_err, messages) => {
+                        expect(messages.length).to.be.equal(10);
+                        done();
+                    });
+                });
+            });
+        });
     });
 });
 
 describe('Settings', () => {
-    it('getInstance() should create a new singleton object', () => {
-        const settings = Settings.getInstance();
-        expect(settings).to.not.equal(undefined);
-    });
-
-    it('getInstance() always returns the same instance', () => {
-        let settings = Settings.getInstance();
-        settings.filename = 'test123_%';
-        settings = Settings.getInstance();
-        expect(settings.filename).to.equal('test123_%');
+    beforeEach(() => {
+        const filename = 'test.fbmessengerrc';
+        Settings.filename = filename;
+        Settings.filepath = path.resolve('.', filename);
     });
 
     it('save() and load()', (done) => {
         const options = {'lights': 'on', 'engine': 'on', 'fuel_pump': 'on', 'running': true};
-        const settings = Settings.getInstance();
-        const file = '.test_settings';
+        const settings = Settings;
 
         settings.properties = options;
-        settings.filename = file;
         settings.save();
 
-        settings.load((err, result) => {
+        settings.read((err, result) => {
             expect(result).to.deep.equal(options);
             done();
         });
-
     });
 });


### PR DESCRIPTION
# Problem

Whenever a user has to wipe out their `.kryptonite` or `.settings`, they have to navigate to wherever `fb-messenger-cli` is installed. In addition, the file names `.kryptonite` and `.settings` do not make much sense if they are found elsewhere.

# Proposal

This pull request changes `.kyptonite` to `.fbmessenger.enc` and `.settings` to `.fbmessengerrc`, and stores them in the user's home directory.

In addition to this, it fixes the regression tests, so that whenever they are run, a users' settings are not altered. The tests also now won't ping @Alex-Rose directly. :wink: 