### PR TITLE
feat: add command to change display name repeatedly or not

### DIFF
--- a/lib/interactive.js
+++ b/lib/interactive.js
@@ -74,9 +74,8 @@ function getDisplayName(author) {
     return colorList[colorPosition](displayName);
 }
 
-function renderMessage(author, message) {
-    let msg = `${getDisplayName(author)}: `;
-  
+function renderMessage(author, message, showAuthor = true) {
+    let msg = showAuthor ? `${getDisplayName(author)}: ` : ``;
     if (Settings.properties.showTimestamps) {
     
         const timeDifference = Date.now() - message.timestamp;
@@ -212,15 +211,35 @@ InteractiveCli.prototype.initializeConversationViewFromFbid = function(id) {
             refreshConsole();
             attsNo = 0;
             atts = [];
+            // for store previous author name
+            let previousAuthorString = "";
+            const msgLength = messages.length;
+            const linesToShow = Settings.properties.threadLineLimit > 0
+            ? Math.min(msgLength, Settings.properties.threadLineLimit)
+            : msgLength;
+            // display author name repeatedly or not
+            const showPreAuthor = Settings.properties.showPreAuthor;
+            // calculate which line is first line
+            const firstShowMsgLine = msgLength - linesToShow;
             for (const i in messages) {
                 const message = messages[i];
                 let authorString = message.author;
-
                 if (authorString.indexOf('fbid:') === 0)
                     authorString = authorString.substr('fbid:'.length);
-
+                // Determine whether to display author name
+                let showAuthor = true;
+                if (previousAuthorString == authorString && !showPreAuthor) {
+                    showAuthor = false;
+                }
+                if (!showPreAuthor) {
+                    previousAuthorString = authorString;
+                }
+                // first line have to show author name
+                if (i == firstShowMsgLine && !showPreAuthor) {
+                    showAuthor = true;
+                }
                 const author = messenger.users[authorString];
-                const msg = renderMessage(author, message);
+                const msg = renderMessage(author, message, showAuthor);
 
                 interactive.threadHistory.push(msg);
             }
@@ -429,6 +448,7 @@ InteractiveCli.prototype.handleCommands = function(command) {
             console.log('/timestamp ........ Toggle timestamp for messages'.cyan);
             console.log('/linelimit [#] .... Set max number of messages to display in a conversation'.cyan);
             console.log('/nolimit .......... Unset a line limit, display all available messages'.cyan);
+            console.log('/repeat............ Display name repeatedly or not(default repeatedly)'.cyan);
             console.log('/help ............. Print this message'.cyan);
             rlInterface.prompt(true);
             break;
@@ -485,7 +505,13 @@ InteractiveCli.prototype.handleCommands = function(command) {
                 interactive.handleCommands("/refresh");
             }
             break;
+        case '/repeat':
+            Settings.properties.showPreAuthor = !Settings.properties.showPreAuthor;
+            Settings.save();
+            console.log(`Changed display author name settings!`.cyan);
 
+            interactive.handleCommands("/refresh");
+            break;
         default:
             console.log('Unknown command. Type /help for commands.'.cyan);
             rlInterface.prompt(true);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -23,7 +23,8 @@ class Settings {
             twoFactorAuth: false,
             headlessLogin: true,
             noSandbox: true,
-            logonTimeout: 86400000 // 24hrs in ms
+            logonTimeout: 86400000, // 24hrs in ms
+            showPreAuthor: true
         };
     }
 


### PR DESCRIPTION
### Original Issue: https://github.com/Alex-Rose/fb-messenger-cli/issues/190

Add command `/repeat` to switch the mode which can display name repeatedly or not.
if switch mode not to repeatedly, it would check previous author name is the same, if it's the same, not to display.
NOTE: every first message's author name would display